### PR TITLE
Add article 06: task-based transferable DSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,31 @@ This paper combines the physics-based scatter kernel superposition (SKS) method 
 - Produced lower errors than both the conventional SKS method and other deep learning-based methods on simulated projections and reconstructed CT volumes.
 - Evaluation was limited to a single chest phantom anatomy; generalization to other body regions was not assessed.
 --------
+<br/>
+<br/>
+
+## 06. Task-based transferable deep-learning scatter correction in cone beam computed tomography: a simulation study <img src="https://img.shields.io/badge/Supervised-blue.svg" alt="Supervised"> <img src="https://img.shields.io/badge/Projection--domain-yellow.svg" alt="Projection-domain">
+J. P. Cruz-Bastida et al. *Journal of Medical Imaging*, 2024. [[doi](https://doi.org/10.1117/1.JMI.11.2.024006)][[paper](https://pmc.ncbi.nlm.nih.gov/articles/PMC10960584/)][[code](https://github.com/calcutech/task-based-DSC)]
+### Summary
+
+**Key Idea**:
+
+This paper proposes a two-stage transfer learning strategy for CBCT scatter correction. A U-Net CNN is first pre-trained on a large dataset of simple geometric phantom projections to learn general scatter patterns, then fine-tuned with a small task-specific dataset of anthropomorphic phantom projections. This reduces both the data requirements and training time needed to adapt the scatter correction model to new imaging tasks.
+
+**Methodology**:
+
+- A U-Net architecture with seven downsampling stages predicts 2D scatter ratio maps ($SR = S/T$) from log-normalized projection data at 512×256 pixel resolution (0.784 mm pixel size).
+- Pre-training used 5,184 image pairs from 24 cylindrical phantom configurations (varied diameter and length). Transfer learning required only 250 training pairs per imaging task (~12× less data than pre-training).
+- Loss function: $L = 1 - \text{SSIM}$, optimized with Adam (learning rate $1 \times 10^{-4}$). Pre-training ran for 150 epochs (~6 hours on an NVIDIA RTX 3060); transfer learning converged in ~50 epochs (~5 minutes, ~70× faster).
+- Monte Carlo simulations were generated using fastCAT software to produce ground truth scatter distributions.
+- Evaluated on simulated adult head and pediatric pelvis imaging tasks.
+
+**Results**:
+
+- Pre-trained CNN achieved SSIM $\geq$ 0.91 for scatter ratio predictions across all test cases, with the most frequent SSIM range being (0.99, 1.0).
+- Task-specific CNNs after transfer learning achieved SSIM $\geq$ 0.93 for both adult head and pediatric pelvis tasks.
+- Reconstructed CBCT images achieved CT number accuracy within $\pm$25 HU ($\pm$2.5%).
+- Pediatric pelvis reconstructions showed lower SSIM than adult head, attributed to greater anatomical complexity.
+- Validation was limited to simulation data only; no real experimental CBCT acquisitions were tested. No direct comparison with existing scatter correction methods was provided.
+--------
 


### PR DESCRIPTION
## Summary
- Adds article 06: Cruz-Bastida et al. "Task-based transferable deep-learning scatter correction in cone beam computed tomography: a simulation study" (JMI, 2024).
- Transfer learning approach: pre-trains U-Net on geometric phantoms, then fine-tunes with ~12× less data and ~70× less time on task-specific anthropomorphic phantoms.
- Includes DOI, open-access paper link (PMC), and public code repository (GitHub).